### PR TITLE
Fix: open skills dialog on click on the community page

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -305,9 +305,11 @@
                     .update(obj)
                     .then(function(snapshot) {
                         console.log('update: success');
+                        app.spinning = false;
                     }, function(error) {
                         Sentry.captureException(error);
                         console.log('update: error', error);
+                        app.spinning = false;
                     });
             }
 
@@ -402,11 +404,21 @@
                             skills: []
                         });
                     }
-                    document.getElementById("loginStatus").innerHTML = `${userDisplayName} (<a style="color:white" href="#" onclick="signOut()">Sign Out</a>)`;
                     peopleArrToDatabaseDic(app.people);
                 } else {
                     app.userGitHubName = app.people[index].username;
                 }
+
+                document.getElementById('user').addEventListener(
+                    'click',
+                    function () {
+                        app.displayCard = true;
+                        app.cardDisplayName = app.people[index].displayname;
+                        app.cardGitHubName = app.people[index].username;
+                        app.cardUID = app.people[index].uid;
+                        app.cardSkills = app.people[index].skills;
+                    }
+                )
             }
 
             Quasar.Dark.set(true);

--- a/js/init-firebase.js
+++ b/js/init-firebase.js
@@ -5,7 +5,7 @@ function initApp(app) {
       const { displayName, photoURL, providerData } = user;
       document.querySelector("#userAvatar img").src = photoURL;
       document.querySelector("#userAvatar").style.display = "inline-block";
-      document.getElementById("loginStatus").innerHTML = `${displayName} (<a style="color:white" href="#" onclick="signOut()">Sign Out</a>)`;
+      document.getElementById("loginStatus").innerHTML = `<span id="user">${displayName}<span> (<a style="color:white" href="#" onclick="signOut()">Sign Out</a>)`;
 
       const { uid } = providerData[0];
       app.userSignedIn = true;


### PR DESCRIPTION
- Open skill editors when the logged user name is clicked.

It only works for the community page for now, the skills card/dialog is not present on other pages.