### PR TITLE
Hotfix: Check element is not null before referencing it

### DIFF
--- a/ohbm2020/index.html
+++ b/ohbm2020/index.html
@@ -330,6 +330,7 @@
     function websocketUpdate(update) {
       const {id: key, count} = update;
       const el = document.getElementById(`${key}`);
+      if(!el) { return; }
       if(count === 0) {
         el.classList.remove("connected");
         el.innerText = "";


### PR DESCRIPTION
The real problem must be explored, but for the sake of preserving Sentry's quota, this fix should help.